### PR TITLE
リリースフローの修正

### DIFF
--- a/.github/workflows/push_release_tag.yml
+++ b/.github/workflows/push_release_tag.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_PAT }}
       - name: Cache node modules
         uses: actions/cache@v2
         env:
@@ -30,6 +32,6 @@ jobs:
       - name: Push tag and deploy
         run: |
           npm ci --ignore-scripts
-          git config user.name '${{ github.actor }}'
-          git config user.email '${{ github.actor }}@users.noreply.github.com'
+          git config user.name 'github-actions'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           npm run deploy

--- a/.github/workflows/update_internal_modules.yml
+++ b/.github/workflows/update_internal_modules.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           echo "::set-output name=count::$(git diff --name-only | wc -l)"
       - name: Create commits
-        if: 0 < steps.diff.outputs.count
+        if: 2 <= steps.diff.outputs.count # package.json, package-lock.json
         run: |
           git config user.name 'github-actions'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
@@ -59,7 +59,7 @@ jobs:
           git commit -m "Update to ${{ steps.version.outputs.LATEST_VERSION }}"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
-        if: 0 < steps.diff.outputs.count
+        if: 2 <= steps.diff.outputs.count # package.json, package-lock.json
         with:
           title: update to akashic-engine@${{ steps.version.outputs.LATEST_VERSION }}
           branch: update_akashic_engine/${{ steps.version.outputs.LATEST_VERSION }}

--- a/README.md
+++ b/README.md
@@ -170,24 +170,20 @@ npm run build
 npm test
 ```
 
-## リリース
+## 内部モジュールの自動更新
 
-以下のコマンドを実行します。
+`.github/workflows/update_internal_modules.yml` で定義されたスケジュールに応じて akashic-engine の更新を監視します。
+akashic-engine の更新が確認された場合、そのバージョンに追従する PullRequest が自動で作成されます。
 
-```sh
-npm run deploy
-```
+上記の PullRequest が main ブランチにマージされると `.github/workflows/push_release_tag.yml` によりリリースタグが GitHub 上に発行されます。
+リリースタグの発行後、`.github/workflows/release_and_upload_assets.yml` により成果物を含めたリリースノートが自動的に作成されます。
 
-リリースは GitHub Actions で自動的に実行されます。
-通常のリリースの場合、`npm run deploy` を手動で実行する必要はありません。
+なお、このワークフローを実行するには以下の secrets をリポジトリに登録する必要があります。
+([参考](https://docs.github.com/ja/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token))
 
-## リリースフロー
-
-* akashic-engine が更新され、新しいバージョンが publish される
-* `Update internal modules` workflow が1日1回呼び出され、 akashic-engine のバージョンを確認する
-  * 更新があれば、これを取り込んだ PR を作成する
-* PR が main ブランチにマージされると、`Push Release Tag` workflow が新しいタグを最新コミットに付ける
-* 新しいタグが付くと、 `Release and Upload Assets` workflow がリリースを作成する
+| secrets 変数名 | 内容                        |
+| ------------- | -------------------------- |
+| `GH_PAT`      | GitHub の個人アクセストークン  |
 
 ## ライセンス
 本リポジトリは MIT License の元で公開されています。


### PR DESCRIPTION
# このPullRequestが解決する内容
デフォルトのアクセストークン (`GITHUB_TOKEN`) を利用すると新しいワークフローが実行されないという GitHub Actions の仕様により、README に記載されているリリースフローが正しく実行されていないことがわかりました。
参考: https://docs.github.com/ja/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token

そこでリリースフローの前段であるタグの発行時に、個人アクセストークン `GH_PAT` を利用するように修正します。